### PR TITLE
List all Shopcarts

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -100,7 +100,7 @@ def delete_shopcart(shopcart_id):
 def list_all_shopcarts():
     """
     List all shopcarts.
-    Returns a JSON that contains all shopcarts.
+    Returns a JSON that contains all shopcarts under the key 'shopcarts'.
     """
     shopcart = Shopcart()
     shopcarts = {"shopcarts": []}

--- a/service/routes.py
+++ b/service/routes.py
@@ -94,6 +94,24 @@ def delete_shopcart(shopcart_id):
 
 
 ######################################################################
+# LIST ALL SHOPCARTS
+######################################################################
+@app.route("/shopcarts", methods=["GET"])
+def list_all_shopcarts():
+    """
+    List all shopcarts.
+    Returns a JSON that contains all shopcarts.
+    """
+    shopcart = Shopcart()
+    shopcarts = {"shopcarts": []}
+    for sc in shopcart.all():
+        shopcarts["shopcarts"].append(sc.serialize())
+    app.logger.info(f"Retrieved shopcarts: {shopcarts}")
+
+    return shopcarts, status.HTTP_200_OK
+
+
+######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -124,3 +124,13 @@ class TestShopcartServer(TestCase):
             f"{BASE_URL}/{shopcart.id}"
         ) 
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_list_all_shopcarts(self):
+        """It should List all existing shopcarts."""
+        shopcarts = [sc.serialize() for sc in self._create_shopcarts(5)]
+        resp = self.client.get(
+            f"{BASE_URL}"
+        )
+        resp_dict = resp.get_json()
+        
+        self.assertEqual(resp_dict["shopcarts"], shopcarts)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -132,5 +132,5 @@ class TestShopcartServer(TestCase):
             f"{BASE_URL}"
         )
         resp_dict = resp.get_json()
-        
+
         self.assertEqual(resp_dict["shopcarts"], shopcarts)


### PR DESCRIPTION
In the corresponding story we said `Then it returns a list of the shopcarts`, and I'm implementing this by returning a JSON with a key `shopcarts` containing all shopcarts.

An example of output looks like this:
```
{
  "shopcarts": [
    {
      "customer_id": 7788,
      "id": 1,
      "items": []
    },
    {
      "customer_id": 7788,
      "id": 2,
      "items": []
    },
    {
      "customer_id": 7788,
      "id": 3,
      "items": []
    }
  ]
}
```

Let me know if you folks have any questions!
