### PR TITLE
Delete Nodeport in Postgresql.yaml

### DIFF
--- a/deploy/postgresql.yaml
+++ b/deploy/postgresql.yaml
@@ -29,18 +29,18 @@ spec:
                   name: postgres-creds
                   key: password
           volumeMounts:
-          - name: postgres-storage
-            mountPath: /var/lib/postgresql/data
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
           # resources:
           #   limits:
           #     cpu: "0.20"
           #     memory: "64Mi"
           #   requests:
-          #     cpu: "0.10"        
+          #     cpu: "0.10"
           #     memory: "32Mi"
       volumes:
-      - name: postgres-storage
-        emptyDir: {}
+        - name: postgres-storage
+          emptyDir: {}
 
 ---
 apiVersion: v1
@@ -56,7 +56,6 @@ spec:
   ports:
     - port: 5432
       targetPort: 5432
-      nodePort: 31032
 
 ---
 # This secret can also be created from the command line using environment variables


### PR DESCRIPTION
Delete Nodeport in Postgresql.yaml. Or the nodeport will be used by both dev and prod namespace which causes conflict.